### PR TITLE
update test coverage badge

### DIFF
--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -51,7 +51,3 @@ jobs:
               uses: codecov/codecov-action@v5
               with:
                 token: ${{ secrets.CODECOV_TOKEN }}
-                name: codecov-floras
-                fail_ci_if_error: true
-                files: coverage.xml
-                verbose: true

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -46,7 +46,7 @@ jobs:
                 pdm add pytest pytest-cov
             - name: Run tests with coverage
               run: |
-                pdm run pytest --cov-branch --cov-report=xml
+                pdm run pytest --cov-branch --cov-report xml:htmlcov/coverage.xml
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v5
               with:

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -46,12 +46,12 @@ jobs:
                 pdm add pytest pytest-cov
             - name: Run tests with coverage
               run: |
-                pdm run pytest --cov-branch --cov-report xml:htmlcov/coverage.xml
+                pdm run pytest --cov-branch --cov-report xml:coverage.xml
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v5
               with:
                 token: ${{ secrets.CODECOV_TOKEN }}
                 name: codecov-floras
                 fail_ci_if_error: true
-                files: htmlcov/*
+                files: coverage.xml
                 verbose: true

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -43,7 +43,7 @@ jobs:
                 pdm run python get_spot.py
             - name: Install dependencies
               run: |
-                pip install pytest pytest-cov
+                pdm add pytest pytest-cov
             - name: Run tests with coverage
               run: |
                 pdm run pytest --cov-branch --cov-report=xml

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -47,6 +47,9 @@ jobs:
             - name: Run tests with coverage
               run: |
                 pdm run pytest --cov-branch --cov-report xml:coverage.xml
+            - name: check files
+              run: |
+                ls -l
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v5
               with:

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -1,0 +1,58 @@
+name: Coverage
+on:
+  push:
+  pull_request:
+
+jobs:
+  get-test-coverage:
+    name: Get test coverage
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.11
+
+      - uses: pdm-project/setup-pdm@v4
+        with:
+            python-version: ${{ matrix.python-version }}
+            cache: true
+      - name: Setup testing environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+              libgraphviz-dev \
+              graphviz
+      - name: Install Python dependencies
+        run: |
+          pdm install
+      - name: Try to use cached Spot
+        id: cache-spot
+        uses: actions/cache@v4
+        with:
+            path: spot-2.12
+            key: setup-pdm-Linux-X64-python-3.11-${{ hashFiles('pyproject.toml') }}
+      - name: Install Spot
+        if: steps.cache-spot.outputs.cache-hit == 'true'
+        run: |
+          cd spot-2.12
+          make install
+      - name: Build and install Spot
+        if: steps.cache-spot.outputs.cache-hit != 'true'
+        run: |
+          pdm run python get_spot.py
+      - name: Run tests
+        run: |
+          pdm run pytest --cov-branch --cov-report=xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          name: codecov-floras
+          fail_ci_if_error: true
+          files: htmlcov/*
+          verbose: true

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -1,58 +1,57 @@
 name: Coverage
 on:
-  push:
-  pull_request:
+    push:
+    pull_request:
 
 jobs:
-  get-test-coverage:
-    name: Get test coverage
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out Git repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.11
-
-      - uses: pdm-project/setup-pdm@v4
-        with:
-            python-version: ${{ matrix.python-version }}
-            cache: true
-      - name: Setup testing environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-              libgraphviz-dev \
-              graphviz
-      - name: Install Python dependencies
-        run: |
-          pdm install
-      - name: Try to use cached Spot
-        id: cache-spot
-        uses: actions/cache@v4
-        with:
-            path: spot-2.12
-            key: setup-pdm-Linux-X64-python-3.11-${{ hashFiles('pyproject.toml') }}
-      - name: Install Spot
-        if: steps.cache-spot.outputs.cache-hit == 'true'
-        run: |
-          cd spot-2.12
-          make install
-      - name: Build and install Spot
-        if: steps.cache-spot.outputs.cache-hit != 'true'
-        run: |
-          pdm run python get_spot.py
-      - name: Run tests
-        run: |
-          pdm run pytest --cov-branch --cov-report=xml
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          name: codecov-floras
-          fail_ci_if_error: true
-          files: htmlcov/*
-          verbose: true
+    get-test-coverage:
+        name: Test coverage
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: ["ubuntu-latest"]
+                python-version: ['3.11']
+        steps:
+            - uses: actions/checkout@v4
+            - uses: pdm-project/setup-pdm@v4
+              with:
+                  python-version: ${{ matrix.python-version }}
+                  cache: true
+            - name: Setup testing environment
+              run: |
+                sudo apt-get update
+                sudo apt-get install -y \
+                    libgraphviz-dev \
+                    graphviz
+            - name: Install Python dependencies
+              run: |
+                pdm install
+            - name: Try to use cached Spot
+              id: cache-spot
+              uses: actions/cache@v4
+              with:
+                  path: spot-2.12
+                  key: ${{ runner.os }}-${{ matrix.python-version }}-spot-${{ hashFiles('get_spot.py') }}-${{ hashFiles('pyproject.toml') }}
+            - name: Install Spot
+              if: steps.cache-spot.outputs.cache-hit == 'true'
+              run: |
+                cd spot-2.12
+                make install
+            - name: Build and install Spot
+              if: steps.cache-spot.outputs.cache-hit != 'true'
+              run: |
+                pdm run python get_spot.py
+            - name: Install dependencies
+              run: |
+                pip install pytest pytest-cov
+            - name: Run tests with coverage
+              run: |
+                pdm run pytest --cov-branch --cov-report=xml
+            - name: Upload coverage reports to Codecov
+              uses: codecov/codecov-action@v5
+              with:
+                token: ${{ secrets.CODECOV_TOKEN }}
+                name: codecov-floras
+                fail_ci_if_error: true
+                files: htmlcov/*
+                verbose: true

--- a/.github/workflows/coverage_report.yaml
+++ b/.github/workflows/coverage_report.yaml
@@ -46,7 +46,7 @@ jobs:
                 pdm add pytest pytest-cov
             - name: Run tests with coverage
               run: |
-                pdm run pytest --cov-branch --cov-report xml:coverage.xml
+                pdm run pytest --cov --cov-report=xml:coverage.xml
             - name: check files
               run: |
                 ls -l

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Ubuntu Build with PDM](https://github.com/jgraeb/floras/actions/workflows/ubuntu_build_pdm.yaml/badge.svg?branch=main)](https://github.com/jgraeb/floras/actions/workflows/ubuntu_build_pdm.yaml)
 [![Ubuntu Build with conda](https://github.com/jgraeb/floras/actions/workflows/ubuntu_build_conda.yaml/badge.svg?branch=main)](https://github.com/jgraeb/floras/actions/workflows/ubuntu_build_conda.yaml)
 
-[![Coverage Status](./reports/coverage/coverage-badge.svg?dummy=8484744)](./reports/htmlcov/index.html)
+[![codecov](https://codecov.io/github/jgraeb/floras/graph/badge.svg?token=XB5ZDOWZK2)](https://codecov.io/github/jgraeb/floras)
 [![Lint](https://github.com/jgraeb/floras/actions/workflows/lint.yaml/badge.svg?branch=main)](https://github.com/jgraeb/floras/actions/workflows/lint.yaml)
 
 # Floras: Flow-Based Reactive Test Synthesis for Autonomous Systems


### PR DESCRIPTION
I used codecov, currently linked to my GitHub account and my fork of the repo to dynamically generate the badge using a GitHub workflow. We might need to sign the tulip-control organization up for codecov to use the main project repo.